### PR TITLE
Don't show 'Open Image' in command palette

### DIFF
--- a/extensions/markdown-language-features/package.json
+++ b/extensions/markdown-language-features/package.json
@@ -259,6 +259,10 @@
           "when": "false"
         },
         {
+          "command": "_markdown.openImage",
+          "when": "false"
+        },
+        {
           "command": "markdown.showPreview",
           "when": "editorLangId == markdown && !notebookEditorFocused",
           "group": "navigation"


### PR DESCRIPTION
This removes the open image from the command palette.
